### PR TITLE
Multiple Joystick

### DIFF
--- a/src/com/zerokol/views/JoystickView.java
+++ b/src/com/zerokol/views/JoystickView.java
@@ -247,7 +247,7 @@ public class JoystickView extends View implements Runnable {
 		this.loopInterval = repeatInterval;
 	}
 
-	public static interface OnJoystickMoveListener {
+	public interface OnJoystickMoveListener {
 		public void onValueChanged(int angle, int power, int direction);
 	}
 


### PR DESCRIPTION
By removing the static modifier of the interface it is possible to create multiple joysticks with multiple OnJoystickMoveListener.